### PR TITLE
Modified --skipQC to match parameter in rnaseq main.nf

### DIFF
--- a/scripts/nextflow/nf-core-rnaseq-example.ipynb
+++ b/scripts/nextflow/nf-core-rnaseq-example.ipynb
@@ -86,7 +86,7 @@
     "            \"s3://{0}/{1}\".format(workflowBucket, workflowFolderPrefix),\n",
     "            \"--reads\", \"s3://1000genomes/phase3/data/HG00243/sequence_read/SRR*_{1,2}.filt.fastq.gz\",\n",
     "            \"--genome\", \"GRCh37\",\n",
-    "            \"--skip_qc\"\n",
+    "            \"--skipQC\"\n",
     "        ]\n",
     "    }\n",
     ")\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Testing the QuickStart failed, traced the issue to "--skip_qc" vs "--skipQC", with the latter matching the parameter in nf-core/rnaseq/main.nf.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
