### PR TITLE
Update bb.nextflow.template

### DIFF
--- a/templates/bb.nextflow.template
+++ b/templates/bb.nextflow.template
@@ -332,7 +332,7 @@ Resources:
       Parameters:
         S3DataBucketName: !Ref S3BucketName
         S3NextflowBucketName: !Ref S3BucketName
-        ExistingBucket: !Ref ExistingBucket
+        ExistingBucket: Yes
         S3NextflowPrefix: !Ref S3NextflowPrefix
         S3LogsDirPrefix: !Ref S3LogsDirPrefix
         S3WorkDirPrefix: !Ref S3WorkDirPrefix


### PR DESCRIPTION
When you have the bb.nextflow.template create a new bucket it first does so in `S3Stack`. However, that `ExistingBucket=No` is propagated to `NextflowStack`. That stack again will try to create the S3 bucket and will fail because it was already created.

Changing line 335 to `ExistingBucket: Yes` fixes this. At this point, either the bucket was existing at launch or was already created as part of `S3Stack` so it is always existing by this point.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
